### PR TITLE
Document prereq for Singer-io tap-gitlab

### DIFF
--- a/_data/meltano/extractors/tap-gitlab/singer-io.yml
+++ b/_data/meltano/extractors/tap-gitlab/singer-io.yml
@@ -14,3 +14,5 @@ repo: https://github.com/singer-io/tap-gitlab
 domain_url:
 maintenance_status: unknown
 keywords: []
+prereqs: |
+  Before installing this tap, the `pytz` library needs to be pre-installed.


### PR DESCRIPTION
Install doesn't work by default. This attempts to improve that.